### PR TITLE
Config client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Running tests
 Run a Kinto server in background::
 
     $ pip install kinto
-    $ kinto start --ini config.ini
+    $ kinto start --ini kinto.ini
 
 Then run the tests using cargo in a single thread::
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -23,7 +23,10 @@ fn main() {
     let client = KintoClient::new(KintoConfig::new(server_url.to_owned(), auth.into()));
 
     // Pick a new record using the default bucket
-    let ref mut new_record = client.bucket("default").collection("notes").new_record();
+    let ref mut new_record = client
+        .bucket("default")
+        .collection("notes")
+        .new_record();
 
     // Set some stuff
     new_record.data = Some(json!({"title": "Hello World"}));
@@ -32,8 +35,10 @@ fn main() {
     new_record.set().unwrap();
 
     // Get the created record by id
-    let mut get_record =
-        client.bucket("default").collection("notes").record(new_record.get_id().unwrap());
+    let mut get_record = client
+        .bucket("default")
+        .collection("notes")
+        .record(new_record.get_id().unwrap());
 
     // Get the record from the server or panic if fails
     get_record.load().unwrap();

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,7 +5,7 @@ extern crate serde_json;
 
 
 use hyper::header::{Authorization, Basic};
-use kinto_http::{KintoClient, Resource};
+use kinto_http::{KintoClient, KintoConfig, Resource};
 use serde_json::to_string_pretty;
 
 
@@ -20,7 +20,7 @@ fn main() {
                              });
 
     // Create a client.
-    let client = KintoClient::new(server_url.to_owned(), auth.into());
+    let client = KintoClient::new(KintoConfig::new(server_url.to_owned(), auth.into()));
 
     // Pick a new record using the default bucket
     let ref mut new_record = client.bucket("default").collection("notes").new_record();

--- a/examples/permissions.rs
+++ b/examples/permissions.rs
@@ -6,7 +6,7 @@ extern crate serde_json;
 
 
 use hyper::header::{Authorization, Basic};
-use kinto_http::{KintoClient, Resource};
+use kinto_http::{KintoClient, KintoConfig, Resource};
 
 
 fn main() {
@@ -20,7 +20,7 @@ fn main() {
                              });
 
     // Create a client.
-    let client = KintoClient::new(server_url.to_owned(), auth.into());
+    let client = KintoClient::new(KintoConfig::new(server_url.to_owned(), auth.into()));
 
     // Pick a new record using the default bucket
     let mut new_bucket = client.new_bucket();
@@ -34,7 +34,7 @@ fn main() {
     println!("{:?}", new_bucket.permissions);
 
     // Create an unautheticated client.
-    let pub_client = KintoClient::new(server_url.to_owned(), None);
+    let pub_client = KintoClient::new(KintoConfig::new(server_url.to_owned(), None));
 
 
     // Get the created record by id

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -81,7 +81,8 @@ impl From<ResponseWrapper> for BatchResponseWrapper {
     fn from(batch_wrapper: ResponseWrapper) -> Self {
         let mut responses = vec![];
 
-        for resp in batch_wrapper.body
+        for resp in batch_wrapper
+                .body
                 .get("responses")
                 .unwrap()
                 .as_array()

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -148,7 +148,7 @@ mod test_bucket_resource {
     fn test_set_bucket() {
         let mut bucket = setup_bucket();
         bucket.set().unwrap();
-        let data = bucket.data.unwrap().to_owned();
+        let data = bucket.data.unwrap();
         assert_eq!(data["id"], "food");
     }
 
@@ -157,7 +157,7 @@ mod test_bucket_resource {
         let mut bucket = setup_bucket();
         bucket.id = None;
         bucket.set().unwrap();
-        let data = bucket.data.unwrap().to_owned();
+        let data = bucket.data.unwrap();
         assert!(data["id"].as_str() != None);
     }
 
@@ -165,7 +165,7 @@ mod test_bucket_resource {
     fn test_create_bucket() {
         let mut bucket = setup_bucket();
         bucket.create().unwrap();
-        let data = bucket.data.unwrap().to_owned();
+        let data = bucket.data.unwrap();
         assert_eq!(data["id"], "food");
     }
 
@@ -174,7 +174,7 @@ mod test_bucket_resource {
         let mut bucket = setup_bucket();
         bucket.id = None;
         bucket.set().unwrap();
-        let data = bucket.data.unwrap().to_owned();
+        let data = bucket.data.unwrap();
         assert!(data["id"].as_str() != None);
     }
 
@@ -182,7 +182,7 @@ mod test_bucket_resource {
     fn test_load_bucket() {
         let mut bucket = setup_bucket();
         bucket.set().unwrap();
-        let create_data = bucket.data.clone().unwrap();
+        let create_data = bucket.data.unwrap();
 
         // Cleanup stored data to make sure load work
         bucket.data = json!({}).into();
@@ -198,7 +198,7 @@ mod test_bucket_resource {
         let mut bucket = setup_bucket();
         bucket.data = json!({"good": true}).into();
         bucket.create().unwrap();
-        let data = bucket.data.unwrap().to_owned();
+        let data = bucket.data.unwrap();
         assert_eq!(data["good"].as_bool().unwrap(), true);
     }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -44,7 +44,7 @@ impl Bucket {
         }
     }
 
-    pub fn new_by_id<'a>(config: KintoConfig, id: &'a str) -> Self {
+    pub fn new_by_id(config: KintoConfig, id: &str) -> Self {
         Bucket {
             config: config,
             data: None,
@@ -54,7 +54,7 @@ impl Bucket {
     }
 
     /// Get a collection by id.
-    pub fn collection<'a>(self, id: &'a str) -> Collection {
+    pub fn collection(self, id: &str) -> Collection {
         return Collection::new_by_id(self, id);
     }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,7 +1,7 @@
 use serde_json;
 use serde_json::Value;
 
-use KintoClient;
+use KintoConfig;
 use error::KintoError;
 use request::KintoRequest;
 use response::ResponseWrapper;
@@ -24,29 +24,29 @@ pub struct BucketPermissions {
 }
 
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Bucket {
     pub data: Option<Value>,
     pub permissions: BucketPermissions,
-    pub client: KintoClient,
     pub id: Option<String>,
+    pub config: KintoConfig,
 }
 
 
 impl Bucket {
     /// Create a new bucket resource.
-    pub fn new(client: KintoClient) -> Self {
+    pub fn new(config: KintoConfig) -> Self {
         Bucket {
-            client: client,
+            config: config,
             data: None,
             permissions: BucketPermissions::default(),
             id: None,
         }
     }
 
-    pub fn new_by_id<'a>(client: KintoClient, id: &'a str) -> Self {
+    pub fn new_by_id<'a>(config: KintoConfig, id: &'a str) -> Self {
         Bucket {
-            client: client,
+            config: config,
             data: None,
             permissions: BucketPermissions::default(),
             id: Some(id.to_owned()),
@@ -90,10 +90,6 @@ impl Resource for Bucket {
         self.id = Some(wrapper.body["data"]["id"].as_str().unwrap().to_owned());
     }
 
-    fn get_client(&self) -> KintoClient {
-        self.client.clone()
-    }
-
     fn get_id(&self) -> Option<&str> {
         // Try to get id from class
         match self.id.as_ref() {
@@ -132,6 +128,10 @@ impl Resource for Bucket {
 
     fn get_permissions(&self) -> Option<Value> {
         serde_json::to_value(&(self.permissions)).unwrap_or_default().into()
+    }
+
+    fn get_config(&self) -> KintoConfig {
+        self.config.clone()
     }
 }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -127,7 +127,9 @@ impl Resource for Bucket {
     }
 
     fn get_permissions(&self) -> Option<Value> {
-        serde_json::to_value(&(self.permissions)).unwrap_or_default().into()
+        serde_json::to_value(&(self.permissions))
+            .unwrap_or_default()
+            .into()
     }
 
     fn get_config(&self) -> KintoConfig {

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,44 +10,59 @@ use bucket::Bucket;
 
 use utils::unwrap_collection_records;
 
-
-/// Client for the Kinto HTTP API.
-#[derive(Debug)]
-pub struct KintoClient {
+/// Configuration of the Kinto endpoint.
+#[derive(Debug, Clone)]
+pub struct KintoConfig {
     pub server_url: String,
-    pub http_client: client::Client,
     pub auth: Option<Authorization<Basic>>,
 }
 
+impl KintoConfig {
+    pub fn new(server_url: String, auth: Option<Authorization<Basic>>) -> KintoConfig {
+        KintoConfig {
+            server_url: server_url,
+            auth: auth,
+        }
+    }
 
-impl KintoClient {
-    /// Create a client.
-    pub fn new(server_url: String, auth: Option<Authorization<Basic>>) -> KintoClient {
-
+    pub fn http_client(&self) -> client::Client {
         // Build an SSL connector
         let ssl = NativeTlsClient::new().unwrap();
         let connector = HttpsConnector::new(ssl);
 
         // Build a HTTP Client with TLS support.
-        let client = client::Client::with_connector(connector);
+        client::Client::with_connector(connector)
+    }
+}
+
+/// Client for the Kinto HTTP API.
+#[derive(Debug)]
+pub struct KintoClient {
+    pub http_client: client::Client,
+    config: KintoConfig,
+}
+
+
+impl KintoClient {
+    /// Create a client.
+    pub fn new(config: KintoConfig) -> KintoClient {
 
         KintoClient {
-            server_url: server_url,
-            http_client: client,
-            auth: auth,
+            config: config.clone(),
+            http_client: config.http_client(),
         }
     }
 
     /// Select an existing bucket.
-    pub fn bucket<'a>(&self, id: &'a str) -> Bucket {
+    pub fn bucket(&self, id: &str) -> Bucket {
         // XXX: Cloning prevents move, but there should be a better way to
         // handle this. Using references maybe?
-        Bucket::new_by_id(self.clone(), id)
+        Bucket::new_by_id(self.config.clone(), id)
     }
 
     /// Create a new empty bucket with a generated id.
     pub fn new_bucket(&self) -> Bucket {
-        Bucket::new(self.clone())
+        Bucket::new(self.config.clone())
     }
 
     /// List the names of all available buckets.
@@ -64,40 +79,19 @@ impl KintoClient {
 
     /// Flush the server (if the flush endpoint is enabled).
     pub fn flush(&self) -> Result<(), KintoError> {
-        let path = format!("{}/__flush__", self.server_url);
-
         // Set authentication headers
         let mut headers = Headers::new();
-        match self.auth.to_owned() {
-            Some(method) => headers.set(method),
-            None => (),
-        };
+        if let Some(ref method) = self.config.auth {
+            headers.set(method.clone());
+        }
 
         try!(self.http_client
-                 .post(path.as_str())
+                 .post(&format!("{}/__flush__", self.config.server_url))
                  .headers(headers)
                  .send());
         Ok(())
     }
 }
-
-
-impl Clone for KintoClient {
-    fn clone(&self) -> KintoClient {
-        let new_client = KintoClient::new(self.server_url.to_owned(),
-                                          self.auth.to_owned());
-        return new_client;
-    }
-}
-
-
-impl Default for KintoClient {
-    fn default() -> KintoClient {
-        let new_client = KintoClient::new("".to_owned(), None);
-        return new_client;
-    }
-}
-
 
 #[cfg(test)]
 mod test_client {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -43,7 +43,7 @@ impl Collection {
     }
 
     /// Create a new collection resource.
-    pub fn new_by_id<'a>(bucket: Bucket, id: &'a str) -> Self {
+    pub fn new_by_id(bucket: Bucket, id: &str) -> Self {
         Collection {
             bucket: bucket,
             id: Some(id.to_owned()),
@@ -52,7 +52,7 @@ impl Collection {
         }
     }
 
-    pub fn record<'a>(&self, id: &'a str) -> Record {
+    pub fn record(&self, id: &str) -> Record {
         return Record::new_by_id(self.clone(), id);
     }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -128,7 +128,9 @@ impl Resource for Collection {
     }
 
     fn get_permissions(&self) -> Option<Value> {
-        serde_json::to_value(&(self.permissions)).unwrap_or_default().into()
+        serde_json::to_value(&(self.permissions))
+            .unwrap_or_default()
+            .into()
     }
 }
 
@@ -245,7 +247,8 @@ mod test_collection {
         }
 
         let resource = Record::new(collection.clone());
-        let response = resource.list_request()
+        let response = resource
+            .list_request()
             .unwrap()
             .limit(3)
             .follow_subrequests()
@@ -276,7 +279,8 @@ mod test_collection {
         }
 
         let resource = Record::new(collection.clone());
-        resource.delete_all_request()
+        resource
+            .delete_all_request()
             .unwrap()
             .limit(5)
             .follow_subrequests()

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,7 +1,7 @@
 use serde_json;
 use serde_json::Value;
 
-use KintoClient;
+use KintoConfig;
 use error::KintoError;
 use request::KintoRequest;
 use response::ResponseWrapper;
@@ -22,7 +22,7 @@ pub struct CollectionPermissions {
 }
 
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Collection {
     pub data: Option<Value>,
     pub permissions: CollectionPermissions,
@@ -88,8 +88,8 @@ impl Resource for Collection {
         self.id = Some(wrapper.body["data"]["id"].as_str().unwrap().to_owned());
     }
 
-    fn get_client(&self) -> KintoClient {
-        self.bucket.get_client()
+    fn get_config(&self) -> KintoConfig {
+        self.bucket.get_config()
     }
 
     fn get_id(&self) -> Option<&str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod utils;
 
 pub use error::KintoError;
 pub use client::KintoClient;
+pub use client::KintoConfig;
 
 pub use bucket::Bucket;
 pub use collection::Collection;

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,7 +1,7 @@
 use serde_json;
 use serde_json::Value;
 
-use KintoClient;
+use KintoConfig;
 use error::KintoError;
 use response::ResponseWrapper;
 use resource::Resource;
@@ -17,7 +17,7 @@ pub struct RecordPermissions {
 }
 
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Record {
     pub data: Option<Value>,
     pub permissions: RecordPermissions,
@@ -61,8 +61,8 @@ impl Resource for Record {
         self.id = Some(wrapper.body["data"]["id"].as_str().unwrap().to_owned());
     }
 
-    fn get_client(&self) -> KintoClient {
-        self.collection.get_client()
+    fn get_config(&self) -> KintoConfig {
+        self.collection.get_config()
     }
 
     fn get_data(&self) -> Option<Value> {

--- a/src/record.rs
+++ b/src/record.rs
@@ -75,7 +75,9 @@ impl Resource for Record {
     }
 
     fn get_permissions(&self) -> Option<Value> {
-        serde_json::to_value(&(self.permissions)).unwrap_or_default().into()
+        serde_json::to_value(&(self.permissions))
+            .unwrap_or_default()
+            .into()
     }
 
     fn get_id(&self) -> Option<&str> {

--- a/src/record.rs
+++ b/src/record.rs
@@ -38,7 +38,7 @@ impl Record {
     }
 
     /// Create a new record object with an id.
-    pub fn new_by_id<'a>(collection: Collection, id: &'a str) -> Self {
+    pub fn new_by_id(collection: Collection, id: &str) -> Self {
         Record {
             collection: collection,
             data: None,

--- a/src/request.rs
+++ b/src/request.rs
@@ -82,7 +82,8 @@ pub trait KintoRequest: Clone {
         };
 
         // Send prepared request
-        let response = preparer.config
+        let response = preparer
+            .config
             .http_client()
             .request(preparer.method.to_owned(), &full_path)
             .headers(headers)
@@ -143,8 +144,9 @@ pub trait KintoRequest: Clone {
 
             // Remove client prefix
             temp_request.preparer().path =
-                next_page_url.as_str().replace(base_response.config.server_url.as_str(),
-                                               "");
+                next_page_url
+                    .as_str()
+                    .replace(base_response.config.server_url.as_str(), "");
             temp_request.preparer().query = "".to_owned();
 
             current_response = try!(temp_request.send());

--- a/src/request.rs
+++ b/src/request.rs
@@ -137,16 +137,14 @@ pub trait KintoRequest: Clone {
             };
 
             // Gets nets page string
-            let next_page_url = try!(str::from_utf8(page_header.as_slice())).to_owned();
+            let next_page_url = try!(str::from_utf8(page_header.as_slice()));
 
             // Repeated request on the provided endpoint
             let mut temp_request = self.clone();
 
             // Remove client prefix
             temp_request.preparer().path =
-                next_page_url
-                    .as_str()
-                    .replace(base_response.config.server_url.as_str(), "");
+                next_page_url.replace(base_response.config.server_url.as_str(), "");
             temp_request.preparer().query = "".to_owned();
 
             current_response = try!(temp_request.send());

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -126,11 +126,12 @@ pub trait Resource: Clone {
             return self.create();
         }
 
-        let wrapper =
-            match try!(self.update_request()).body(self.get_body().into()).send() {
-                Ok(wrapper) => wrapper,
-                Err(value) => return Err(value),
-            };
+        let wrapper = match try!(self.update_request())
+                  .body(self.get_body().into())
+                  .send() {
+            Ok(wrapper) => wrapper,
+            Err(value) => return Err(value),
+        };
         self.unwrap_response(wrapper);
         Ok(())
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use hyper::header::{IfMatch, IfNoneMatch};
 
-use client::KintoClient;
+use client::KintoConfig;
 use error::KintoError;
 use request::{GetRecord, CreateRecord, UpdateRecord, DeleteRecord, GetCollection,
               DeleteCollection, KintoRequest, PayloadedEndpoint};
@@ -25,8 +25,8 @@ pub trait Resource: Clone {
     /// Unwrap a request response and update the current object.
     fn unwrap_response(&mut self, wrapper: ResponseWrapper);
 
-    /// Get the client for the given resource.
-    fn get_client(&self) -> KintoClient;
+    /// Get the config for the given resource.
+    fn get_config(&self) -> KintoConfig;
 
     /// Get the record data.
     fn get_data(&self) -> Option<Value>;
@@ -82,32 +82,32 @@ pub trait Resource: Clone {
 
     /// create a custom load (GET) request for the endpoint.
     fn load_request(&self) -> Result<GetRecord, KintoError> {
-        Ok(GetRecord::new(self.get_client(), try!(self.record_path())))
+        Ok(GetRecord::new(self.get_config(), try!(self.record_path())))
     }
 
     /// create a custom create (POST) request for the endpoint.
     fn create_request(&self) -> Result<CreateRecord, KintoError> {
-        Ok(CreateRecord::new(self.get_client(), try!(self.resource_path())))
+        Ok(CreateRecord::new(self.get_config(), try!(self.resource_path())))
     }
 
     /// Create a custom update (PUT) request for the endpoint.
     fn update_request(&self) -> Result<UpdateRecord, KintoError> {
-        Ok(UpdateRecord::new(self.get_client(), try!(self.record_path())))
+        Ok(UpdateRecord::new(self.get_config(), try!(self.record_path())))
     }
 
     /// Create a custom delete request for the endpoint.
     fn delete_request(&self) -> Result<DeleteRecord, KintoError> {
-        Ok(DeleteRecord::new(self.get_client(), try!(self.record_path())))
+        Ok(DeleteRecord::new(self.get_config(), try!(self.record_path())))
     }
 
     /// Create a custom list collections request.
     fn list_request(&self) -> Result<GetCollection, KintoError> {
-        Ok(GetCollection::new(self.get_client(), try!(self.resource_path())))
+        Ok(GetCollection::new(self.get_config(), try!(self.resource_path())))
     }
 
     /// Create a custom delete collections request.
     fn delete_all_request(&self) -> Result<DeleteCollection, KintoError> {
-        Ok(DeleteCollection::new(self.get_client(), try!(self.resource_path())))
+        Ok(DeleteCollection::new(self.get_config(), try!(self.resource_path())))
     }
 
     /// Load bucket by id if exists.

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,13 +2,13 @@ use hyper::status::StatusCode;
 use hyper::header::Headers;
 use serde_json::Value;
 
-use KintoClient;
+use KintoConfig;
 
 
 /// Wrapper for a Kinto response object.
 #[derive(Debug, Clone)]
 pub struct ResponseWrapper {
-    pub client: KintoClient,
+    pub config: KintoConfig,
     pub path: String,
     pub status: StatusCode,
     pub headers: Headers,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,10 +99,10 @@ pub mod tests {
     pub fn setup_record() -> Record {
         let client = setup_client();
         client.bucket("food").set().unwrap();
-        client.bucket("food")
-            .collection("meat")
-            .set()
-            .unwrap();
-        return client.bucket("food").collection("meat").record("entrecote");
+        client.bucket("food").collection("meat").set().unwrap();
+        return client
+                   .bucket("food")
+                   .collection("meat")
+                   .record("entrecote");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,14 +57,14 @@ pub mod tests {
     use hyper::header::{Authorization, Basic};
 
     use KintoClient;
+    use KintoConfig;
     use resource::Resource;
     use bucket::Bucket;
     use collection::Collection;
     use record::Record;
 
-
-    /// Create a client and clean the server.
-    pub fn setup_client() -> KintoClient {
+    /// Create a config.
+    pub fn setup_config() -> KintoConfig {
         //let server_url = "https://kinto.dev.mozaws.net/v1".to_owned();
         let server_url = "http://localhost:8888/v1".to_owned();
 
@@ -72,9 +72,14 @@ pub mod tests {
                                      username: "a".to_owned(),
                                      password: Some("a".to_owned()),
                                  });
-        let client = KintoClient::new(server_url, auth.into());
+        KintoConfig::new(server_url, auth.into())
+    }
+
+    /// Create a client and clean the server.
+    pub fn setup_client() -> KintoClient {
+        let client = KintoClient::new(setup_config());
         client.flush().unwrap();
-        return client;
+        client
     }
 
 


### PR DESCRIPTION
The main change is the split up of the KintoClient struct to keep the clonable config part on its own. That way we only send around KintoConfig structs instead of the full KintoClient with a custom clone implementation.

The other commits are just small cleanups.