### PR TITLE
Straighten out infinite recursion in error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,34 +14,35 @@ pub enum KintoError {
     UndefinedIdError,
     UnavailableEndpointError,
     HyperError,
-    JsonError,
-    IOError,
+    JsonError(JsonError),
+    Utf8Error(Utf8Error),
+    IOError(IOError),
 }
 
 
 impl From<IOError> for KintoError {
     fn from(err: IOError) -> Self {
-        err.into()
+        KintoError::IOError(err)
     }
 }
 
 
 impl From<Utf8Error> for KintoError {
     fn from(err: Utf8Error) -> Self {
-        err.into()
+        KintoError::Utf8Error(err)
     }
 }
 
 
 impl From<JsonError> for KintoError {
     fn from(err: JsonError) -> Self {
-        err.into()
+        KintoError::JsonError(err)
     }
 }
 
 
 impl From<HyperError> for KintoError {
     fn from(err: HyperError) -> Self {
-        err.into()
+        KintoError::HyperError
     }
 }


### PR DESCRIPTION
This seems like the cause of failures in e.g. #18.

It seems like the original intent was just to return error codes
without any additional information. This wasn't possible for Utf8Error
because there was no constructor for this error. Also, add some
"cause" information for these errors so that we can get a little extra
information when we fail.

